### PR TITLE
Add missing cmake dependencies

### DIFF
--- a/abseil-cpp/seed.sh
+++ b/abseil-cpp/seed.sh
@@ -3,7 +3,7 @@ DESC="Abseil Common Libraries (C++)"
 VERSION="20230802.0"
 SOURCE="https://github.com/abseil/abseil-cpp/archive/refs/tags/${VERSION}.tar.gz"
 CHECKSUM="f40605e07aa804aa82e7090f12db7e34"
-DEPS=""
+DEPS="cmake"
 FLAGS=""
 
 _setup()

--- a/cppcheck/seed.sh
+++ b/cppcheck/seed.sh
@@ -3,7 +3,7 @@ DESC="Static source code analysis tool for C and C++ code"
 VERSION="2.10"
 SOURCE="https://sourceforge.net/projects/cppcheck/files/cppcheck/${VERSION}/cppcheck-${VERSION}.tar.gz"
 CHECKSUM="584b5114ca903c7e4739493586825c18"
-DEPS=""
+DEPS="cmake"
 FLAGS=""
 
 _setup()

--- a/dlib/seed.sh
+++ b/dlib/seed.sh
@@ -3,7 +3,7 @@ DESC="Modern C++ toolkit containing machine learning algorithms and tools for cr
 VERSION="19.24"
 SOURCE="http://dlib.net/files/dlib-${VERSION}.tar.bz2"
 CHECKSUM="8a98957a73eebd3cd7431c2bac79665f"
-DEPS="libjpeg-turbo libpng libice libwebp openblas"
+DEPS="cmake libjpeg-turbo libpng libice libwebp openblas"
 FLAGS=""
 
 _setup()

--- a/poco/seed.sh
+++ b/poco/seed.sh
@@ -3,7 +3,7 @@ DESC="Powerful cross-platform C++ libraries for building network- and internet-b
 VERSION="1.12.4"
 SOURCE="https://github.com/pocoproject/poco/archive/refs/tags/poco-${VERSION}-release.tar.gz"
 CHECKSUM="0ca5d1e2f2a5e8ba2f0a83c2e6df374a"
-DEPS="openssl"
+DEPS="cmake openssl"
 FLAGS=""
 
 _setup()

--- a/protobuf/seed.sh
+++ b/protobuf/seed.sh
@@ -3,7 +3,7 @@ DESC="Protocol Buffers - Google's data interchange format"
 VERSION="24.0"
 SOURCE="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protobuf-${VERSION}.tar.gz"
 CHECKSUM="efcc79da4c891186d24b2a70da484da1"
-DEPS="abseil-cpp"
+DEPS="cmake abseil-cpp"
 FLAGS=""
 
 _setup()

--- a/uchardet/seed.sh
+++ b/uchardet/seed.sh
@@ -3,7 +3,7 @@ DESC="Encoding detector library"
 VERSION="0.0.8"
 SOURCE="https://www.freedesktop.org/software/uchardet/releases/uchardet-${VERSION}.tar.xz"
 CHECKSUM="9e267be7aee81417e5875086dd9d44fd"
-DEPS=""
+DEPS="cmake"
 FLAGS=""
 
 _setup()

--- a/vulkan-headers/seed.sh
+++ b/vulkan-headers/seed.sh
@@ -3,7 +3,7 @@ DESC="Vulkan header files and API registry"
 VERSION="1.3.261"
 SOURCE="https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${VERSION}.tar.gz"
 CHECKSUM="58ca8e891dd68aa3afc5ea18f9d64aa8"
-DEPS=""
+DEPS="cmake"
 FLAGS=""
 
 _setup()


### PR DESCRIPTION
Some packages were using cmake as a build tool but didn't have it as a dependency. This isn't consistent since there were some packages that did have cmake as a dependency