### PR TITLE
Add missing meson + ninja deps

### DIFF
--- a/at-spi2-core/seed.sh
+++ b/at-spi2-core/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.46.0"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/at-spi2-core/${SHORT_VERSION}/at-spi2-core-${VERSION}.tar.xz"
 CHECKSUM="16e85a40442d80be960b4e1e3992fd5b"
-DEPS="dbus glib gsettings-desktop-schemas xorg-libs"
+DEPS="dbus glib gsettings-desktop-schemas xorg-libs meson ninja"
 FLAGS=""
 
 _setup()

--- a/atkmm/seed.sh
+++ b/atkmm/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.28.3"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/atkmm/${SHORT_VERSION}/atkmm-${VERSION}.tar.xz"
 CHECKSUM="bad12606feaaba28c4d31b8857b7099e"
-DEPS="at-spi2-core glibmm"
+DEPS="at-spi2-core glibmm meson ninja"
 FLAGS=""
 
 _setup()

--- a/babl/seed.sh
+++ b/babl/seed.sh
@@ -4,7 +4,7 @@ VERSION="0.1.98"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gimp.org/pub/babl/${SHORT_VERSION}/babl-${VERSION}.tar.xz"
 CHECKSUM="0fd5f826e2ef14de04d978c203a3fe28"
-DEPS="librsvg little-cms"
+DEPS="librsvg little-cms meson ninja"
 FLAGS="test"
 
 _setup()

--- a/bubblewrap/seed.sh
+++ b/bubblewrap/seed.sh
@@ -3,7 +3,7 @@ DESC="Setuid implementation of user namespaces, or sandboxing, that provides acc
 VERSION="0.7.0"
 SOURCE="https://github.com/containers/bubblewrap/releases/download/v${VERSION}/bubblewrap-${VERSION}.tar.xz"
 CHECKSUM="37892167cbc3bd2a54b396033892e2ae"
-DEPS=""
+DEPS="meson ninja"
 FLAGS="test"
 
 _setup()

--- a/elogind/seed.sh
+++ b/elogind/seed.sh
@@ -3,7 +3,7 @@ DESC="systemd project's 'logind', extracted to be a standalone daemon"
 VERSION="246.10"
 SOURCE="https://github.com/elogind/elogind/archive/v${VERSION}/elogind-${VERSION}.tar.gz"
 CHECKSUM="32ab2201281f14738d9c045f3669c14d"
-DEPS="dbus linux-pam eudev"
+DEPS="dbus linux-pam eudev meson ninja"
 FLAGS="32bit test"
 
 _setup()

--- a/fribidi/seed.sh
+++ b/fribidi/seed.sh
@@ -3,7 +3,7 @@ DESC="Implementation of the Unicode Bidirectional Algorithm (BIDI)"
 VERSION="1.0.12"
 SOURCE="https://github.com/fribidi/fribidi/releases/download/v${VERSION}/fribidi-${VERSION}.tar.xz"
 CHECKSUM="21185b398635a7fc0d3ff0a7578c4791"
-DEPS=""
+DEPS="meson ninja"
 FLAGS="test"
 
 _setup()

--- a/fuse/seed.sh
+++ b/fuse/seed.sh
@@ -3,7 +3,7 @@ DESC="FUSE (Filesystem in Userspace) is a simple interface for userspace program
 VERSION="3.13.1"
 SOURCE="https://github.com/libfuse/libfuse/releases/download/fuse-${VERSION}/fuse-${VERSION}.tar.xz"
 CHECKSUM="f2830b775bcba2ab9cb94f2619c077a4"
-DEPS=""
+DEPS="meson ninja"
 FLAGS=""
 
 _setup()

--- a/gdk-pixbuf/seed.sh
+++ b/gdk-pixbuf/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.42.10"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/gdk-pixbuf/${SHORT_VERSION}/gdk-pixbuf-${VERSION}.tar.xz"
 CHECKSUM="4a62f339cb1424693fba9bb7ffef8150"
-DEPS="glib libjpeg-turbo libpng shared-mime-info libtiff"
+DEPS="glib libjpeg-turbo libpng shared-mime-info libtiff meson ninja"
 FLAGS="32bit test"
 
 # TODO: Add librsvg runtime dependency when rustc has been packaged (>_<)

--- a/glib-networking/seed.sh
+++ b/glib-networking/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.76.1"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/glib-networking/${SHORT_VERSION}/glib-networking-${VERSION}.tar.xz"
 CHECKSUM="05b519bb1f009789e6b82af88ed1b59a"
-DEPS="glib gnutls make-ca"
+DEPS="glib gnutls make-ca meson ninja"
 FLAGS="test"
 
 _setup()

--- a/glib/seed.sh
+++ b/glib/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.74.5"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/glib/${SHORT_VERSION}/glib-${VERSION}.tar.xz"
 CHECKSUM="7561501d9f63f3418ddb23d2903cc968"
-DEPS="libxslt pcre2"
+DEPS="libxslt pcre2 meson ninja"
 FLAGS="32bit"
 
 _setup()

--- a/glibmm/seed.sh
+++ b/glibmm/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.66.5"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/glibmm/${SHORT_VERSION}/glibmm-${VERSION}.tar.xz"
 CHECKSUM="b6c2c8ba36abf6c5e43cee459a74b8a1"
-DEPS="glib libsigc++"
+DEPS="glib libsigc++ meson ninja"
 FLAGS=""
 
 _setup()

--- a/glu/seed.sh
+++ b/glu/seed.sh
@@ -3,7 +3,7 @@ DESC="Mesa OpenGL Utility library"
 VERSION="9.0.2"
 SOURCE="ftp://ftp.freedesktop.org/pub/mesa/glu/glu-${VERSION}.tar.xz"
 CHECKSUM="2b0f13fa5b949bfb3a995927c6e35125"
-DEPS="mesa"
+DEPS="mesa meson ninja"
 FLAGS=""
 
 _setup()

--- a/gobject-introspection/seed.sh
+++ b/gobject-introspection/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.74.0"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/gobject-introspection/${SHORT_VERSION}/gobject-introspection-${VERSION}.tar.xz"
 CHECKSUM="ed4e290c5ca8737a62c9a7f5347ae10d"
-DEPS="glib"
+DEPS="glib meson ninja"
 FLAGS=""
 
 _setup()

--- a/graphene/seed.sh
+++ b/graphene/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.10.8"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/graphene/${SHORT_VERSION}/graphene-${VERSION}.tar.xz"
 CHECKSUM="169e3c507b5a5c26e9af492412070b81"
-DEPS="glib gobject-introspection"
+DEPS="glib gobject-introspection meson ninja"
 FLAGS="test"
 
 _setup()

--- a/gsettings-desktop-schemas/seed.sh
+++ b/gsettings-desktop-schemas/seed.sh
@@ -4,7 +4,7 @@ VERSION="43.0"
 MAJOR_VERSION="$(major_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/gsettings-desktop-schemas/${MAJOR_VERSION}/gsettings-desktop-schemas-${VERSION}.tar.xz"
 CHECKSUM="38f3f153be78402cbd18e3d4b44ba0fa"
-DEPS="glib gobject-introspection"
+DEPS="glib gobject-introspection meson ninja"
 FLAGS=""
 
 _setup()

--- a/gst-plugins-base/seed.sh
+++ b/gst-plugins-base/seed.sh
@@ -3,7 +3,7 @@ DESC="Well-groomed and well-maintained collection of GStreamer plug-ins and elem
 VERSION="1.22.0"
 SOURCE="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${VERSION}.tar.xz"
 CHECKSUM="c559f23bb746bda732e85ba7b76c2074"
-DEPS="gstreamer alsa-lib gobject-introspection iso-codes libgudev libjpeg-turbo libogg libpng libtheora libvorbis mesa pango wayland-protocols xorg-libs"
+DEPS="gstreamer alsa-lib gobject-introspection iso-codes libgudev libjpeg-turbo libogg libpng libtheora libvorbis mesa pango wayland-protocols xorg-libs meson ninja"
 FLAGS="test"
 
 _setup()

--- a/gstreamer/seed.sh
+++ b/gstreamer/seed.sh
@@ -3,7 +3,7 @@ DESC="Streaming media framework"
 VERSION="1.22.0"
 SOURCE="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${VERSION}.tar.xz"
 CHECKSUM="fb69587308e03e15c1b9a026a7b591d6"
-DEPS="glib gobject-introspection"
+DEPS="glib gobject-introspection meson ninja"
 FLAGS="test"
 
 _setup()

--- a/gtk+/seed.sh
+++ b/gtk+/seed.sh
@@ -4,7 +4,7 @@ VERSION="3.24.36"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/gtk+/${SHORT_VERSION}/gtk+-${VERSION}.tar.xz"
 CHECKSUM="fd4571a112ffaa2fbbb9d25de8f5b6c0"
-DEPS="at-spi2-core gdk-pixbuf libepoxy pango sassc libxkbcommon"
+DEPS="at-spi2-core gdk-pixbuf libepoxy pango sassc libxkbcommon meson ninja"
 FLAGS=""
 
 # TODO: Add gobject-introspection support if GNOME support is needed

--- a/gtkmm/seed.sh
+++ b/gtkmm/seed.sh
@@ -4,7 +4,7 @@ VERSION="3.24.7"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/gtkmm/${SHORT_VERSION}/gtkmm-${VERSION}.tar.xz"
 CHECKSUM="9576353c26db5e273a074264b68ad6cf"
-DEPS="atkmm gtk+ pangomm"
+DEPS="atkmm gtk+ pangomm meson ninja"
 FLAGS=""
 
 _setup()

--- a/harfbuzz/seed.sh
+++ b/harfbuzz/seed.sh
@@ -3,7 +3,7 @@ DESC="OpenType text shaping engine"
 VERSION="7.1.0"
 SOURCE="https://github.com/harfbuzz/harfbuzz/releases/download/${VERSION}/harfbuzz-${VERSION}.tar.xz"
 CHECKSUM="761fe38814b74eb6d66f450051604a1f"
-DEPS="icu cmake graphite2"
+DEPS="icu cmake graphite2 meson ninja"
 FLAGS="important"
 
 _setup()

--- a/json-glib/seed.sh
+++ b/json-glib/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.6.6"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/json-glib/${SHORT_VERSION}/json-glib-${VERSION}.tar.xz"
 CHECKSUM="9c40fcd8cdbf484dd1704480afefae14"
-DEPS="glib"
+DEPS="glib meson ninja"
 FLAGS=""
 
 _setup()

--- a/libcairomm/seed.sh
+++ b/libcairomm/seed.sh
@@ -3,7 +3,7 @@ DESC="C++ interface to Cairo"
 VERSION="1.14.0"
 SOURCE="https://www.cairographics.org/releases/cairomm-${VERSION}.tar.xz"
 CHECKSUM="75a08d50eb08b97667e4ea2be6efa1ad"
-DEPS="cairo libsigc++"
+DEPS="cairo libsigc++ meson ninja"
 FLAGS=""
 
 _setup()

--- a/libdrm/seed.sh
+++ b/libdrm/seed.sh
@@ -3,7 +3,7 @@ DESC="Userspace library for accessing the direct rendering manager (DRM)"
 VERSION="2.4.115"
 SOURCE="https://dri.freedesktop.org/libdrm/libdrm-${VERSION}.tar.xz"
 CHECKSUM="5403981a20c964f4c893ff91393652bd"
-DEPS="xorg-libs"
+DEPS="xorg-libs meson ninja"
 FLAGS="32bit"
 
 _setup()

--- a/libepoxy/seed.sh
+++ b/libepoxy/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.5.10"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/libepoxy/${SHORT_VERSION}/libepoxy-${VERSION}.tar.xz"
 CHECKSUM="10c635557904aed5239a4885a7c4efb7"
-DEPS="mesa"
+DEPS="mesa meson ninja"
 FLAGS="test"
 
 _setup()

--- a/libevdev/seed.sh
+++ b/libevdev/seed.sh
@@ -3,7 +3,7 @@ DESC="Common functions for Xorg input drivers"
 VERSION="1.13.0"
 SOURCE="https://www.freedesktop.org/software/libevdev/libevdev-${VERSION}.tar.xz"
 CHECKSUM="5b15b4cf97c4f9f1393e499526a57665"
-DEPS=""
+DEPS="meson ninja"
 FLAGS=""
 
 _setup()

--- a/libgudev/seed.sh
+++ b/libgudev/seed.sh
@@ -3,7 +3,7 @@ DESC="GObject bindings for libudev"
 VERSION="237"
 SOURCE="https://download.gnome.org/sources/libgudev/${VERSION}/libgudev-${VERSION}.tar.xz"
 CHECKSUM="a7783083cd74957d3a727ddc4737ee84"
-DEPS="glib"
+DEPS="glib meson ninja"
 FLAGS=""
 
 _setup()

--- a/libinput/seed.sh
+++ b/libinput/seed.sh
@@ -3,7 +3,7 @@ DESC="Library that handles input devices for display servers and other applicati
 VERSION="1.22.1"
 SOURCE="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${VERSION}/libinput-${VERSION}.tar.gz"
 CHECKSUM="d164313f9a92162df7af3505b6915c76"
-DEPS="libevdev mtdev"
+DEPS="libevdev mtdev meson ninja"
 FLAGS=""
 
 _setup()

--- a/libnotify/seed.sh
+++ b/libnotify/seed.sh
@@ -4,7 +4,7 @@ VERSION="0.8.1"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/libnotify/${SHORT_VERSION}/libnotify-${VERSION}.tar.xz"
 CHECKSUM="1495f279b255b4493ac3588559823158"
-DEPS="gtk+ notification-daemon"
+DEPS="gtk+ notification-daemon meson ninja"
 FLAGS=""
 
 _setup()

--- a/libsigc++/seed.sh
+++ b/libsigc++/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.12.0"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/libsigc++/${SHORT_VERSION}/libsigc++-${VERSION}.tar.xz"
 CHECKSUM="943b7aef5d74fbc4f4a3bb67bcfaae02"
-DEPS="boost libxslt"
+DEPS="boost libxslt meson ninja"
 FLAGS="test"
 
 _setup()

--- a/libslirp/seed.sh
+++ b/libslirp/seed.sh
@@ -3,7 +3,7 @@ DESC="User-mode networking library used by virtual machines, containers or vario
 VERSION="4.7.0"
 SOURCE="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${VERSION}/libslirp-v${VERSION}.tar.bz2"
 CHECKSUM="b815c4de99265559caf5ef635a213609"
-DEPS="glib"
+DEPS="glib meson ninja"
 FLAGS=""
 
 _setup()

--- a/libsoup/seed.sh
+++ b/libsoup/seed.sh
@@ -4,7 +4,7 @@ VERSION="3.4.2"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/libsoup/${SHORT_VERSION}/libsoup-${VERSION}.tar.xz"
 CHECKSUM="cd8b0fc5d53331b9c0b5b22aabac4294"
-DEPS="glib-networking libpsl libxml2 nghttp2 sqlite mit-kerberos5"
+DEPS="glib-networking libpsl libxml2 nghttp2 sqlite mit-kerberos5 meson ninja"
 FLAGS="wip"
 
 _setup()

--- a/libvdpau/seed.sh
+++ b/libvdpau/seed.sh
@@ -3,7 +3,7 @@ DESC="Library which implements the VDPAU library"
 VERSION="1.5"
 SOURCE="https://gitlab.freedesktop.org/vdpau/libvdpau/-/archive/${VERSION}/libvdpau-${VERSION}.tar.bz2"
 CHECKSUM="148a192110e7a49d62c0bf9ef916c099"
-DEPS="xorg-libs mesa"
+DEPS="xorg-libs mesa meson ninja"
 FLAGS=""
 
 _setup()

--- a/libwnck/seed.sh
+++ b/libwnck/seed.sh
@@ -4,7 +4,7 @@ VERSION="43.0"
 MAJOR_VERSION="$(major_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/libwnck/${MAJOR_VERSION}/libwnck-${VERSION}.tar.xz"
 CHECKSUM="cd21ef743a1e9286554401c5b28d5ec6"
-DEPS="gtk+ startup-notification"
+DEPS="gtk+ startup-notification meson ninja"
 FLAGS=""
 
 _setup()

--- a/libxcvt/seed.sh
+++ b/libxcvt/seed.sh
@@ -3,7 +3,7 @@ DESC="A library providing a standalone version of the X server implementation of
 VERSION="0.1.2"
 SOURCE="https://www.x.org/pub/individual/lib/libxcvt-${VERSION}.tar.xz"
 CHECKSUM="b553fdb6024c5a137ff925bf4c337724"
-DEPS=""
+DEPS="meson ninja"
 FLAGS=""
 
 _setup()

--- a/libxkbcommon/seed.sh
+++ b/libxkbcommon/seed.sh
@@ -3,7 +3,7 @@ DESC="Keymap compiler and support library which processes a reduced subset of ke
 VERSION="1.5.0"
 SOURCE="https://xkbcommon.org/download/libxkbcommon-${VERSION}.tar.xz"
 CHECKSUM="40f0486b4eb491928ec6616c2ff85120"
-DEPS="xkeyboard-config libxcb"
+DEPS="xkeyboard-config libxcb meson ninja"
 FLAGS="test"
 
 _setup()

--- a/mesa/seed.sh
+++ b/mesa/seed.sh
@@ -3,7 +3,7 @@ DESC="OpenGL compatible 3D graphics library"
 VERSION="22.3.5"
 SOURCE="https://mesa.freedesktop.org/archive/mesa-${VERSION}.tar.xz"
 CHECKSUM="fdb35ae46968ce517702037710db6a3f"
-DEPS="xorg-libs libdrm mako glslang llvm"
+DEPS="xorg-libs libdrm mako glslang llvm meson ninja"
 FLAGS="32bit"
 
 _setup()

--- a/mpv/seed.sh
+++ b/mpv/seed.sh
@@ -3,7 +3,7 @@ DESC="Command line video player"
 VERSION="0.36.0"
 SOURCE="https://github.com/mpv-player/mpv/archive/refs/tags/v${VERSION}.tar.gz"
 CHECKSUM="3ac8bb1fec1c09293a574e615446bb3b"
-DEPS="xorg-libs pulseaudio ffmpeg zlib libass libjpeg-turbo uchardet libxpresent luajit"
+DEPS="xorg-libs pulseaudio ffmpeg zlib libass libjpeg-turbo uchardet libxpresent luajit meson"
 FLAGS=""
 
 _setup()

--- a/networkmanager/seed.sh
+++ b/networkmanager/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.42.0"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/NetworkManager/${SHORT_VERSION}/NetworkManager-${VERSION}.tar.xz"
 CHECKSUM="cfe8c33493d8d2a9d97415a7042a6fe2"
-DEPS="jansson libndp curl gobject-introspection iptables newt nss polkit pygobject elogind upower vala wpa_supplicant"
+DEPS="jansson libndp curl gobject-introspection iptables newt nss polkit pygobject elogind upower vala wpa_supplicant meson ninja"
 FLAGS=""
 NOTES="Remember to add your normal user to the netdev group to use NetworkManager without root"
 

--- a/p11-kit/seed.sh
+++ b/p11-kit/seed.sh
@@ -3,7 +3,7 @@ DESC="The p11-kit package provides a way to load and enumerate PKCS #11 modules"
 VERSION="0.24.1"
 SOURCE="https://github.com/p11-glue/p11-kit/releases/download/${VERSION}/p11-kit-${VERSION}.tar.xz"
 CHECKSUM="67b2539bdca6b4bedaeecc12864d2796"
-DEPS="libtasn1"
+DEPS="libtasn1 meson ninja"
 FLAGS="test important"
 
 _setup()

--- a/pango/seed.sh
+++ b/pango/seed.sh
@@ -4,7 +4,7 @@ VERSION="1.50.12"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/pango/${SHORT_VERSION}/pango-${VERSION}.tar.xz"
 CHECKSUM="fd4b0b23915d6a0255317f811bea4215"
-DEPS="fontconfig freetype harfbuzz fribidi glib cairo xorg-libs"
+DEPS="fontconfig freetype harfbuzz fribidi glib cairo xorg-libs meson ninja"
 FLAGS=""
 
 # TODO: Add gobject-introspection dependency to this package is GNOME support is needed

--- a/pangomm/seed.sh
+++ b/pangomm/seed.sh
@@ -4,7 +4,7 @@ VERSION="2.46.3"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/pangomm/${SHORT_VERSION}/pangomm-${VERSION}.tar.xz"
 CHECKSUM="7af783bb04de766fafaaad26c9ed475a"
-DEPS="libcairomm glibmm pango"
+DEPS="libcairomm glibmm pango meson ninja"
 FLAGS=""
 
 _setup()

--- a/pipewire/seed.sh
+++ b/pipewire/seed.sh
@@ -3,7 +3,7 @@ DESC="Server and userspace API for handling multimedia pipelines"
 VERSION="0.3.66"
 SOURCE="https://github.com/PipeWire/pipewire/archive/${VERSION}/pipewire-${VERSION}.tar.gz"
 CHECKSUM="8a85d990c159409578b456f8c8dcf075"
-DEPS="alsa-lib dbus"
+DEPS="alsa-lib dbus meson ninja"
 FLAGS="test"
 
 # TODO: There are possibly more dependencies required to install pipewire,

--- a/pixman/seed.sh
+++ b/pixman/seed.sh
@@ -3,7 +3,7 @@ DESC="A library that provides low-level pixel manipulation features such as imag
 VERSION="0.42.2"
 SOURCE="https://www.cairographics.org/releases/pixman-${VERSION}.tar.gz"
 CHECKSUM="a0f6ab8a1d8e0e2cd80e935525e2a864"
-DEPS=""
+DEPS="meson ninja"
 FLAGS=""
 
 _setup()

--- a/playerctl/seed.sh
+++ b/playerctl/seed.sh
@@ -3,7 +3,7 @@ DESC="mpris media player command-line controller"
 VERSION="2.4.1"
 SOURCE="https://github.com/altdesktop/playerctl/archive/refs/tags/v${VERSION}.tar.gz"
 CHECKSUM="795c7f66fb865aa87a301b11f2a78940"
-DEPS="gobject-introspection glib"
+DEPS="gobject-introspection glib meson ninja"
 FLAGS=""
 
 _setup()

--- a/polkit/seed.sh
+++ b/polkit/seed.sh
@@ -3,7 +3,7 @@ DESC="Toolkit for defining and handling authorizations"
 VERSION="122"
 SOURCE="https://gitlab.freedesktop.org/polkit/polkit/-/archive/${VERSION}/polkit-${VERSION}.tar.gz"
 CHECKSUM="bbe3e745fc5bc1a41f1b5044f09a0f26"
-DEPS="glib duktape linux-pam gobject-introspection"
+DEPS="glib duktape linux-pam gobject-introspection meson ninja"
 FLAGS=""
 
 _setup()

--- a/pulseaudio/seed.sh
+++ b/pulseaudio/seed.sh
@@ -3,7 +3,7 @@ DESC="Sound system for POSIX OSes"
 VERSION="16.1"
 SOURCE="https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${VERSION}.tar.xz"
 CHECKSUM="2c7b8ceb5d7337565c7314b4d6087ca8"
-DEPS="libsndfile alsa-lib dbus elogind glib speex xorg-libs"
+DEPS="libsndfile alsa-lib dbus elogind glib speex xorg-libs meson ninja"
 FLAGS=""
 
 _setup()

--- a/pycairo/seed.sh
+++ b/pycairo/seed.sh
@@ -3,7 +3,7 @@ DESC="Python bindings for Cairo"
 VERSION="1.23.0"
 SOURCE="https://github.com/pygobject/pycairo/releases/download/v${VERSION}/pycairo-${VERSION}.tar.gz"
 CHECKSUM="7a3729d21659098e1b9a411b62e88966"
-DEPS="cairo"
+DEPS="cairo meson ninja"
 FLAGS=""
 
 _setup()

--- a/pygobject/seed.sh
+++ b/pygobject/seed.sh
@@ -4,7 +4,7 @@ VERSION="3.42.2"
 SHORT_VERSION="$(short_version $VERSION)"
 SOURCE="https://download.gnome.org/sources/pygobject/${SHORT_VERSION}/pygobject-${VERSION}.tar.xz"
 CHECKSUM="c5b31bb58156661c0954f1dbfc950fc9"
-DEPS="gobject-introspection pycairo"
+DEPS="gobject-introspection pycairo meson ninja"
 FLAGS=""
 
 _setup()

--- a/shared-mime-info/seed.sh
+++ b/shared-mime-info/seed.sh
@@ -3,7 +3,7 @@ DESC="MIME database"
 VERSION="2.2"
 SOURCE="https://gitlab.freedesktop.org/xdg/shared-mime-info/-/archive/${VERSION}/shared-mime-info-${VERSION}.tar.gz"
 CHECKSUM="06cb9e92e4211dc53fd52b7bfd586c78"
-DEPS="glib libxml2"
+DEPS="glib libxml2 meson ninja"
 FLAGS="32bit"
 
 _setup()

--- a/upower/seed.sh
+++ b/upower/seed.sh
@@ -3,7 +3,7 @@ DESC="Interface for enumerating power devices, listening to device events and qu
 VERSION="1.90.0"
 SOURCE="https://gitlab.freedesktop.org/upower/upower/-/archive/v${VERSION}/upower-v${VERSION}.tar.bz2"
 CHECKSUM="4fba71838a9ba0db6f140418eddbe2b7"
-DEPS="libgudev libusb polkit"
+DEPS="libgudev libusb polkit meson ninja"
 FLAGS=""
 
 _setup()

--- a/wayland-protocols/seed.sh
+++ b/wayland-protocols/seed.sh
@@ -3,7 +3,7 @@ DESC="Additional Wayland protocols on top of Wayland core"
 VERSION="1.31"
 SOURCE="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${VERSION}/downloads/wayland-protocols-${VERSION}.tar.xz"
 CHECKSUM="1584de13eb30a4d1f2cd06c08ee24354"
-DEPS="wayland"
+DEPS="wayland meson ninja"
 FLAGS="test"
 
 _setup()

--- a/wayland/seed.sh
+++ b/wayland/seed.sh
@@ -3,7 +3,7 @@ DESC="Compositor protocol"
 VERSION="1.21.0"
 SOURCE="https://gitlab.freedesktop.org/wayland/wayland/-/releases/${VERSION}/downloads/wayland-${VERSION}.tar.xz"
 CHECKSUM="f2653a2293bcd882d756c6a83d278903"
-DEPS="libxml2"
+DEPS="libxml2 meson ninja"
 FLAGS="test"
 
 _setup()

--- a/xkeyboard-config/seed.sh
+++ b/xkeyboard-config/seed.sh
@@ -3,7 +3,7 @@ DESC="Keyboard configuration database for the X Window System"
 VERSION="2.38"
 SOURCE="https://www.x.org/pub/individual/data/xkeyboard-config/xkeyboard-config-${VERSION}.tar.xz"
 CHECKSUM="c89fb974e8f1ba14c64d1bcf3a0f8d11"
-DEPS="xorg-libs"
+DEPS="xorg-libs meson ninja"
 FLAGS=""
 
 _setup()

--- a/xorg-server/seed.sh
+++ b/xorg-server/seed.sh
@@ -3,7 +3,7 @@ DESC="The core of the X Window system"
 VERSION="21.1.8"
 SOURCE="https://www.x.org/pub/individual/xserver/xorg-server-${VERSION}.tar.xz"
 CHECKSUM="79a6eb04b1b17ad6c7aab46da73944e8"
-DEPS="libxcvt pixman font-util xkeyboard-config elogind polkit libtirpc libepoxy libinput xcb-util-keysyms xcb-util-image xcb-util-renderutil xcb-util-wm"
+DEPS="libxcvt pixman font-util xkeyboard-config elogind polkit libtirpc libepoxy libinput xcb-util-keysyms xcb-util-image xcb-util-renderutil xcb-util-wm meson ninja"
 FLAGS=""
 
 _setup()

--- a/xorgproto/seed.sh
+++ b/xorgproto/seed.sh
@@ -3,7 +3,7 @@ DESC="Header files required to build the X Window system"
 VERSION="2022.2"
 SOURCE="https://xorg.freedesktop.org/archive/individual/proto/xorgproto-${VERSION}.tar.xz"
 CHECKSUM="3fdb11d75f7023db273f7b3e34b58338"
-DEPS="util-macros"
+DEPS="util-macros meson ninja"
 FLAGS="32bit"
 
 _setup()

--- a/zathura-pdf-poppler/seed.sh
+++ b/zathura-pdf-poppler/seed.sh
@@ -3,7 +3,7 @@ DESC="PDF support (poppler backend) for zathura"
 VERSION="0.3.0"
 SOURCE="https://git.pwmt.org/pwmt/zathura-pdf-poppler/-/archive/${VERSION}/zathura-pdf-poppler-${VERSION}.tar.gz"
 CHECKSUM="c500be47cfac0e76e81309cfa7847353"
-DEPS="zathura girara poppler poppler-data"
+DEPS="zathura girara poppler poppler-data meson ninja"
 FLAGS=""
 
 _setup()


### PR DESCRIPTION
This should help with tracking packages that might depend on python in any way and also improve the dependency tracking in general.

Having a functional dependency tree will come handy when there are updates